### PR TITLE
Fixed missing import of time

### DIFF
--- a/sensor/DS18B20.py
+++ b/sensor/DS18B20.py
@@ -27,6 +27,7 @@ if __name__ == "__main__" and __package__ is None:
 
 import subprocess
 import sensor
+import time
 from sensor.util import Temperature
 
 class DS18B20(sensor.SensorBase):


### PR DESCRIPTION
When removing a sensor from the bus, reading it would result in an import error in _update_sensor_data:

```
Traceback (most recent call last):
  File "ow_monitor.py", line 18, in <module>
    main()
  File "ow_monitor.py", line 13, in main
    t = ds.temperature()
  File "/usr/local/lib/python3.5/dist-packages/sensor/DS18B20.py", line 40, in temperature
    self._update()
  File "/usr/local/lib/python3.5/dist-packages/sensor/__init__.py", line 103, in _update
    self._update_callback(**kwargs)
  File "/usr/local/lib/python3.5/dist-packages/sensor/__init__.py", line 63, in locked
    func(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/sensor/DS18B20.py", line 52, in _update_sensor_data
    time.sleep(0.2)
NameError: name 'time' is not defined
```